### PR TITLE
Fix typo RFC number and add links to the RFCs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ Fully-Qualified Domain Names
 |Build Status| |Coverage Status| |Latest PyPI Version|
 
 Validates a fully-qualified domain name (FQDN), in full compliance with
-RFC 1035, and the "preferred form" specified in RFC 3686 s. 2.
+`RFC 1035 <https://tools.ietf.org/html/rfc1035>`, and the "preferred form" 
+specified in `RFC 3696 section 2 <https://tools.ietf.org/html/rfc3696#section-2>`_.
 
 Can also convert between absolute and relative FQDNs.
 


### PR DESCRIPTION
The README incorrectly referenced RFC 3686 instead of 3696.